### PR TITLE
feat: Add product properties streams

### DIFF
--- a/tap_veeqo/client.py
+++ b/tap_veeqo/client.py
@@ -13,7 +13,7 @@ class VeeqoStream(RESTStream):
     """Veeqo stream class."""
 
     url_base = "https://api.veeqo.com"
-    primary_keys = ("id",)
+    primary_keys: tuple[str, ...] = ("id",)
     page_size = 100
 
     @property

--- a/tap_veeqo/schemas/product_property.py
+++ b/tap_veeqo/schemas/product_property.py
@@ -1,0 +1,8 @@
+"""Schema definitions for product property objects."""
+
+from singer_sdk import typing as th
+
+ProductPropertyObject = th.PropertiesList(
+    th.Property("id", th.IntegerType),
+    th.Property("name", th.StringType),
+)

--- a/tap_veeqo/schemas/product_property_specific.py
+++ b/tap_veeqo/schemas/product_property_specific.py
@@ -1,0 +1,10 @@
+"""Schema definitions for product property specific objects."""
+
+from singer_sdk import typing as th
+
+ProductPropertySpecificObject = th.PropertiesList(
+    th.Property("id", th.IntegerType),
+    th.Property("product_property_id", th.IntegerType),
+    th.Property("product_property_name", th.StringType),
+    th.Property("value", th.StringType),
+)

--- a/tap_veeqo/schemas/variant_property_specific.py
+++ b/tap_veeqo/schemas/variant_property_specific.py
@@ -1,0 +1,11 @@
+"""Schema definitions for variant property specific objects."""
+
+from singer_sdk import typing as th
+
+VariantPropertySpecificObject = th.PropertiesList(
+    th.Property("id", th.IntegerType),
+    th.Property("product_specific_id", th.IntegerType),
+    th.Property("product_property_id", th.IntegerType),
+    th.Property("product_property_name", th.StringType),
+    th.Property("value", th.StringType),
+)

--- a/tap_veeqo/streams.py
+++ b/tap_veeqo/streams.py
@@ -11,6 +11,7 @@ from tap_veeqo.schemas.employee import EmployeeObject
 from tap_veeqo.schemas.order import OrderObject
 from tap_veeqo.schemas.product import ProductObject
 from tap_veeqo.schemas.product_brand import ProductBrandObject
+from tap_veeqo.schemas.product_property import ProductPropertyObject
 from tap_veeqo.schemas.purchase_order import PurchaseOrderObject
 from tap_veeqo.schemas.sellable import SellableObject
 from tap_veeqo.schemas.store import StoreObject
@@ -67,6 +68,14 @@ class ProductBrandsStream(VeeqoStream):
     name = "product_brands"
     path = "/product_brands"
     schema = ProductBrandObject.to_dict()
+
+
+class ProductPropertiesStream(VeeqoStream):
+    """Define product properties stream."""
+
+    name = "product_properties"
+    path = "/product_properties"
+    schema = ProductPropertyObject.to_dict()
 
 
 class ProductTagsStream(VeeqoStream):

--- a/tap_veeqo/streams.py
+++ b/tap_veeqo/streams.py
@@ -18,6 +18,7 @@ from tap_veeqo.schemas.sellable import SellableObject
 from tap_veeqo.schemas.store import StoreObject
 from tap_veeqo.schemas.supplier import SupplierObject
 from tap_veeqo.schemas.tag import TagObject
+from tap_veeqo.schemas.variant_property_specific import VariantPropertySpecificObject
 from tap_veeqo.schemas.warehouse import WarehouseObject
 
 
@@ -132,6 +133,20 @@ class SellablesStream(VeeqoStream):
     name = "sellables"
     path = "/sellables"
     schema = SellableObject.to_dict()
+
+    @override
+    def get_child_context(self, record, context):
+        return {"id": record["id"]}
+
+
+class VariantPropertySpecificsStream(VeeqoStream):
+    """Define variant property specifics stream."""
+
+    name = "variant_property_specifics"
+    parent_stream_type = SellablesStream
+    path = "/product_variants/{id}/variant_property_specifics"
+    schema = VariantPropertySpecificObject.to_dict()
+    primary_keys = ("id", "product_specific_id", "product_property_id")
 
 
 class StoresStream(VeeqoStream):

--- a/tap_veeqo/streams.py
+++ b/tap_veeqo/streams.py
@@ -12,6 +12,7 @@ from tap_veeqo.schemas.order import OrderObject
 from tap_veeqo.schemas.product import ProductObject
 from tap_veeqo.schemas.product_brand import ProductBrandObject
 from tap_veeqo.schemas.product_property import ProductPropertyObject
+from tap_veeqo.schemas.product_property_specific import ProductPropertySpecificObject
 from tap_veeqo.schemas.purchase_order import PurchaseOrderObject
 from tap_veeqo.schemas.sellable import SellableObject
 from tap_veeqo.schemas.store import StoreObject
@@ -61,6 +62,10 @@ class ProductsStream(VeeqoStream):
     replication_key = "updated_at"
     schema = ProductObject.to_dict()
 
+    @override
+    def get_child_context(self, record, context):
+        return {"id": record["id"]}
+
 
 class ProductBrandsStream(VeeqoStream):
     """Define product brands stream."""
@@ -76,6 +81,16 @@ class ProductPropertiesStream(VeeqoStream):
     name = "product_properties"
     path = "/product_properties"
     schema = ProductPropertyObject.to_dict()
+
+
+class ProductPropertySpecificsStream(VeeqoStream):
+    """Define product property specifics stream."""
+
+    name = "product_property_specifics"
+    parent_stream_type = ProductsStream
+    path = "/products/{id}/product_property_specifics"
+    schema = ProductPropertySpecificObject.to_dict()
+    primary_keys = ("id", "product_property_id")
 
 
 class ProductTagsStream(VeeqoStream):

--- a/tap_veeqo/streams.py
+++ b/tap_veeqo/streams.py
@@ -93,6 +93,13 @@ class ProductPropertySpecificsStream(VeeqoStream):
     primary_keys = ("id", "product_property_id")
 
 
+class ProductOptionSpecificsStream(ProductPropertySpecificsStream):
+    """Define product option specifics stream."""
+
+    name = "product_option_specifics"
+    path = "/products/{id}/product_option_specifics"
+
+
 class ProductTagsStream(VeeqoStream):
     """Define product tags stream."""
 

--- a/tap_veeqo/tap.py
+++ b/tap_veeqo/tap.py
@@ -15,6 +15,7 @@ STREAM_TYPES = [
     streams.OrdersStream,
     streams.ProductsStream,
     streams.ProductBrandsStream,
+    streams.ProductPropertiesStream,
     streams.ProductTagsStream,
     streams.PurchaseOrdersStream,
     streams.SellablesStream,

--- a/tap_veeqo/tap.py
+++ b/tap_veeqo/tap.py
@@ -17,6 +17,7 @@ STREAM_TYPES = [
     streams.ProductBrandsStream,
     streams.ProductPropertiesStream,
     streams.ProductPropertySpecificsStream,
+    streams.ProductOptionSpecificsStream,
     streams.ProductTagsStream,
     streams.PurchaseOrdersStream,
     streams.SellablesStream,

--- a/tap_veeqo/tap.py
+++ b/tap_veeqo/tap.py
@@ -16,6 +16,7 @@ STREAM_TYPES = [
     streams.ProductsStream,
     streams.ProductBrandsStream,
     streams.ProductPropertiesStream,
+    streams.ProductPropertySpecificsStream,
     streams.ProductTagsStream,
     streams.PurchaseOrdersStream,
     streams.SellablesStream,

--- a/tap_veeqo/tap.py
+++ b/tap_veeqo/tap.py
@@ -21,6 +21,7 @@ STREAM_TYPES = [
     streams.ProductTagsStream,
     streams.PurchaseOrdersStream,
     streams.SellablesStream,
+    streams.VariantPropertySpecificsStream,
     streams.StoresStream,
     streams.SuppliersStream,
     streams.TagsStream,


### PR DESCRIPTION
Add streams for:

- Product property definitions (currently undocumented, but related to https://developers.veeqo.com/docs#/reference/products/product-properties)
  ```
  GET https://api.veeqo.com/product_properties
  ```
- Product property/option "specifics", i.e. values (currently undocumented)
  ```
  GET https://api.veeqo.com/products/{id}/product_property_specifics
  GET https://api.veeqo.com/products/{id}/product_option_specifics
  ```
- Variant property "specifics", i.e. values (currently undocumented)
  ```
  GET https://api.veeqo.com/product_variants/{id}/variant_property_specifics
  ```