### PR TITLE
fix: Correct query parameter and increase value for page size

### DIFF
--- a/tap_veeqo/client.py
+++ b/tap_veeqo/client.py
@@ -33,7 +33,7 @@ class VeeqoStream(RESTStream):
     @override
     def get_url_params(self, context, next_page_token):
         params = {
-            "page_size": self.page_size,
+            "per_page": self.page_size,
             "page": next_page_token,
         }
 

--- a/tap_veeqo/client.py
+++ b/tap_veeqo/client.py
@@ -14,7 +14,7 @@ class VeeqoStream(RESTStream):
 
     url_base = "https://api.veeqo.com"
     primary_keys = ("id",)
-    page_size = 100
+    page_size = 1000
 
     @property
     @override


### PR DESCRIPTION
At some point I guess support for the page size query parameter we were using (`page_size`) was dropped and the API fell back to the default page size of 11. Pagination logic otherwise continued to function as normal.

Current working query parameter is `per_page`. Limit seems to have been removed also, so we can increase this to reduce the number of requests made.