### PR TITLE
fix: Only `/sellables` endpoint supports paging with `per_page`

### DIFF
--- a/tap_veeqo/client.py
+++ b/tap_veeqo/client.py
@@ -14,7 +14,7 @@ class VeeqoStream(RESTStream):
 
     url_base = "https://api.veeqo.com"
     primary_keys: tuple[str, ...] = ("id",)
-    page_size = 1000
+    page_size = 100
 
     @property
     @override
@@ -33,7 +33,7 @@ class VeeqoStream(RESTStream):
     @override
     def get_url_params(self, context, next_page_token):
         params = {
-            "per_page": self.page_size,
+            "page_size": self.page_size,
             "page": next_page_token,
         }
 

--- a/tap_veeqo/streams.py
+++ b/tap_veeqo/streams.py
@@ -135,6 +135,15 @@ class SellablesStream(VeeqoStream):
     schema = SellableObject.to_dict()
 
     @override
+    def get_url_params(self, context, next_page_token):
+        params = super().get_url_params(context, next_page_token)
+
+        del params["page_size"]
+        params["per_page"] = 1000
+
+        return params
+
+    @override
     def get_child_context(self, record, context):
         return {"variant_id": record["id"]}
 


### PR DESCRIPTION
Follow up to #83: it seems only the `/sellables` endpoint supports paging with `per_page`, where most other endpoints use `page_size` as previously implemented. The change caused API calls to endpoints that did not support `per_page` to revert to their default page size, causing more requests that necessary.

This fix reverts #83 and implements `per_page` paging for `SellablesStream` only.